### PR TITLE
PS-4223 Use stream_get_contents instead of fread

### DIFF
--- a/Lib/BeanstalkdSocket.php
+++ b/Lib/BeanstalkdSocket.php
@@ -203,7 +203,7 @@ class BeanstalkdSocket {
 			if (feof($this->_connection)) {
 				return false;
 			}
-			$data = fread($this->_connection, $length + 2);
+			$data = stream_get_contents($this->_connection, $length + 2);
 			$meta = stream_get_meta_data($this->_connection);
 
 			if ($meta['timed_out']) {
@@ -212,9 +212,7 @@ class BeanstalkdSocket {
 			}
 			$packet = rtrim($data, "\r\n");
 		} else {
-			$data = fgets($this->_connection, 16384);
-			$packet = rtrim($data, "\r\n");
-			//$packet = stream_get_line($this->_connection, 16384, "\r\n");
+			$packet = stream_get_line($this->_connection, 16384, "\r\n");
 		}
 		return $packet;
 	}


### PR DESCRIPTION
PS-4223 Use stream_get_contents instead of fread to avoid large messages being chucked and lost.
